### PR TITLE
Check for missing wpa_supplicant and create if missing

### DIFF
--- a/lib/wifi.js
+++ b/lib/wifi.js
@@ -1,5 +1,6 @@
 var exec = require('child_process').exec;
 var execSync = require('child_process').execSync;
+const fs = require('fs');
 
 var promiseRetry = require('promise-retry');
 
@@ -12,6 +13,7 @@ const ERR_STOP = 'Could not stop wifi adapter.';
 const ERR_DHCP = 'Could not renew DHCP lease.';
 const ERR_MAX_RETRIES = 'Could not start wifi adapter - Max retries exceeded.'; 
 const ERR_HANDSHAKE = 'Could not get an IP address from the network. Please check credentials.';
+const WPA_SUPPLICANT_PATH = '/etc/wpa_supplicant/wpa_supplicant.conf';
 	
 var commands = {
 	startInterface: 'sudo /sbin/ifup ' + WLAN,
@@ -66,6 +68,13 @@ var wifi = {
 	 * @return {boolean} returns true if no errors
      */	
 	setCreds: function(ssid, psk) {
+		if (!fs.existsSync('/etc/wpa_supplicant/wpa_supplicant.conf')){
+			fs.writeFileSync(WPA_SUPPLICANT_PATH, `network={
+    ssid="${ssid}"
+    psk="${psk}"
+    key_mgmt=WPA-PSK
+}`); }
+
 		
 		return new Promise((resolve, reject) => {
 			
@@ -136,13 +145,14 @@ var wifi = {
 	 * or an Error if rejected.
      */	
 	startInterface: function() {
-
+		
 		return new Promise((resolve, reject) => {
 					
 			exec(commands.startInterface, function(err, stdout, stderr) {
 				if(stdout.indexOf('Failed') == -1 || stdout.indexOf('already configured') > -1) {
 					resolve(true);
 				} else {
+					console.log(stdout);
 					reject(ERR_START);
 				}
 				


### PR DESCRIPTION
If the wpa_supplication.conf file is not found, create it and write the passed credentials. All actions are performed synchronously to ensure that the file exists and is populated with the credentials prior to exec'ing ifup.

Since most of the command called by the library require sudo privileges, I assumed that any node application running with this library would be under su or system and would have permissions to create the file.
